### PR TITLE
[ISSUE-1] 통계, 뉴스 메뉴 바에서 제외

### DIFF
--- a/app/src/main/java/com/example/thingbee_android/MainActivity.java
+++ b/app/src/main/java/com/example/thingbee_android/MainActivity.java
@@ -58,8 +58,8 @@ public class MainActivity extends AppCompatActivity {
         //Tab View
         TabLayout tabs = findViewById(R.id.tabs);
         tabs.addTab(tabs.newTab().setText("지도").setIcon(R.drawable.menu_map_img));
-        tabs.addTab(tabs.newTab().setText("뉴스").setIcon(R.drawable.menu_article_img));
-        tabs.addTab(tabs.newTab().setText("통계").setIcon(R.drawable.menu_statics_img));
+//        tabs.addTab(tabs.newTab().setText("뉴스").setIcon(R.drawable.menu_article_img));
+//        tabs.addTab(tabs.newTab().setText("통계").setIcon(R.drawable.menu_statics_img));
         tabs.addTab(tabs.newTab().setText("설정").setIcon(R.drawable.menu_option_img));
         //tabs.addTab(tabs.newTab().setText("프로토타입"));
         tabs.setTabGravity(tabs.GRAVITY_FILL);


### PR DESCRIPTION
* BEFORE
제공 서비스: 지도(길찾기), 뉴스, 통계, 비상호출

* AFTER
제공 서비스 : 지도(길찾기), 비상호출

>앱에서 제공하는 서비스를 안전 길찾기에 집중하기 위함.
뉴스, 통계 서비스는 길찾기 서비스와 따로 논다는 의견으로 제외



close #1 